### PR TITLE
Add GeometryViewer — WebXR AR viewer for 3D models

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@
 - [Verge3D](https://www.soft8soft.com/verge3d/) - A toolkit that allows 3D artists to export their scenes and create immersive web experiences with ease.
   - [Official Documentation](https://www.soft8soft.com/support-documentation/)
 - [XR Fragments](https://xrfragment.org) - A tiny specification for controlling any 3D model using URLs, based on existing metadata. Promoting hyperlinked WebXR storytelling using all 3D editors and viewers. [[repo]](https://codeberg.org/coderofsalvation/xrfragment)
+- [GeometryViewer](https://geometryviewer.com) - A free, zero-install browser-based 3D model viewer (STL, OBJ, GLTF, GLB, 3MF) with WebXR immersive-AR support on Android and Apple Quick Look on iOS. Share any model via a single link.
  
 ## Learning Resources
 


### PR DESCRIPTION
**GeometryViewer** (https://geometryviewer.com) is a free, zero-install browser-based 3D model viewer with full WebXR AR support.

**Formats:** STL, OBJ, GLTF, GLB, 3MF — auto-detected from file content

**WebXR features:**
- Android: WebXR `immersive-ar` session with hit-test surface placement, pinch-to-scale, two-finger rotation, real-world dimension labels (mm/cm), and environment light estimation
- iOS: Apple Quick Look via USDZ export (no app required)

**Sharing:** Upload a model → get a shareable link → recipient views in 3D/AR in their browser with zero friction. Share URLs include OG meta tags with rendered thumbnails for Discord/Slack/Twitter previews.

Added under **Development → Other** as it's a tool useful to WebXR developers and makers who need to share/preview 3D assets with AR.